### PR TITLE
chore: security update for Github actions usages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,12 @@ updates:
     directory: '/'
     schedule:
       interval: daily
-    ignore:
-      - dependency-name: ad-m/github-push-action
-
+    cooldown:
+      default-days: 15
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: daily
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 15


### PR DESCRIPTION
This pull request is opened automatically by [linz/security-gha-scan](https://github.com/linz/security-gha-scan) to ensure that the usage of Github Actions meets [LINZ security requirements](https://toitutewhenua.atlassian.net/wiki/x/h5SRHQ).

specifically:

- 3rd party actions (anything other than `linz/*`) are pinned with commit SHA
- dependabot is used to keep Github action up to date
  - unverified actions are configured to not auto update
  - cooldown period configured (to 15 days unless repo already has a different config)

Please review and merge it as soon as possible, contact [#team-step-security](https://linz.enterprise.slack.com/archives/C03278T3HCK) or [#team-step-enablement](https://linz.enterprise.slack.com/archives/CMP0BQ2V7) if you have any question.
